### PR TITLE
Fixing Card alignments by adding absolute height values in px

### DIFF
--- a/src/Components/Card/Card.css
+++ b/src/Components/Card/Card.css
@@ -23,11 +23,11 @@
 
 .card__container {
   width: 100%;
-  min-height: 30%;
+  height: 150px;
 }
 .card__img {
   width: 100%;
-  height: auto;
+  height: 100%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
This could also have been fixed via percentage value, but started to misalign in tablet mode. Hence relying on px